### PR TITLE
have travis show coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: go
 
 go:
-  - 1.1
   - 1.2
   - 1.3
   - 1.4
   - 1.5
   - 1.6
   - tip
+
+script: go test -v -cover ./...


### PR DESCRIPTION
- 1.1 does not support the `-cover` flag.

I'm still deciding what I should support, so I'm ok with dropping official go 1.1 support.
